### PR TITLE
Compatibility with angular 10+

### DIFF
--- a/src/jsoneditor.module.ts
+++ b/src/jsoneditor.module.ts
@@ -15,7 +15,7 @@ import {JSONEditorComponent} from './jsoneditor.component';
     ]
 })
 export class JSONEditorModule {
-    static forRoot(): ModuleWithProviders {
+    static forRoot(): ModuleWithProviders<any> {
         return {
             ngModule: JSONEditorModule,
         };


### PR DESCRIPTION
https://v9.angular.io/guide/deprecations#modulewithproviders-type-without-a-generic